### PR TITLE
TCP: Add Linux kernel-based random number generator

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1,6 +1,8 @@
-#if defined __linux__
+#if defined(__linux__)
 #include <fcntl.h>
 #include <linux/random.h>
+#else
+#include <time.h>
 #endif
 
 #include <errno.h>
@@ -252,12 +254,13 @@ static int tcp_fsm(struct tcp_conn_tcb *conn,
             rs->tcp_flags |= TCP_ACK;
             rs->tcp_ack_num = rs->tcp_seqno + 1;
 
-#if defined __linux__
+#if defined(__linux__)
             int fd = open("/dev/urandom", O_RDONLY);
             read(fd, &(rs->tcp_seqno), sizeof(rs->tcp_seqno));
             close(fd);
 #else
-            rs->tcp_seqno = 0;
+            srand(time(NULL));
+            rs->tcp_seqno = rand() % 100;
 #endif
 
             if (sock) {

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -248,9 +248,14 @@ static int tcp_fsm(struct tcp_conn_tcb *conn,
             }
             rs->tcp_flags |= TCP_ACK;
             rs->tcp_ack_num = rs->tcp_seqno + 1;
+
+#if defined __linux__
             int fd = open("/dev/urandom", O_RDONLY);
             read(fd, &(rs->tcp_seqno), sizeof(rs->tcp_seqno));
             close(fd);
+#else
+            rs->tcp_seqno = 0;
+#endif
 
             if (sock) {
                 conn->state = TCP_SYN_RCVD;

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1,7 +1,9 @@
 #include <errno.h>
+#include <fcntl.h>
+#include <linux/random.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
+#include <unistd.h>
 
 #include "nstack_ip.h"
 #include "nstack_socket.h"
@@ -246,8 +248,9 @@ static int tcp_fsm(struct tcp_conn_tcb *conn,
             }
             rs->tcp_flags |= TCP_ACK;
             rs->tcp_ack_num = rs->tcp_seqno + 1;
-            srand(time(NULL));
-            rs->tcp_seqno = rand() % 100;
+            int fd = open("/dev/urandom", O_RDONLY);
+            read(fd, &(rs->tcp_seqno), sizeof(rs->tcp_seqno));
+            close(fd);
 
             if (sock) {
                 conn->state = TCP_SYN_RCVD;

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -1,6 +1,9 @@
-#include <errno.h>
+#if defined __linux__
 #include <fcntl.h>
 #include <linux/random.h>
+#endif
+
+#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Previous generator may not work correctly, so replaced
it with kernel random number source devices