### PR TITLE
Prevent buffer overflow exploit

### DIFF
--- a/src/linux/ether.c
+++ b/src/linux/ether.c
@@ -119,7 +119,11 @@ int ether_init(char *const args[])
 
     /* TODO Parse args */
     if (args[0]) { /* Non-default IF */
-        strcpy(if_name, args[0]);
+        if (strnlen(args[0], IFNAMSIZ) < IFNAMSIZ) { /* prevent buffer overflow */
+            strcpy(if_name, args[0]);
+        } else {
+            return -2;
+        }
     } else { /* Default IF */
         strcpy(if_name, DEFAULT_IF);
     }

--- a/src/nstack.c
+++ b/src/nstack.c
@@ -358,7 +358,11 @@ int main(int argc, char *argv[])
     if (handle == -1) {
         perror("Failed to init");
         exit(1);
+    } else if (handle == -2) {
+        perror("Interface identifier is too long");
+        exit(1);
     }
+
 
     if (ip_config(handle, 167772162, 4294967040)) {
         perror("Failed to config IP");

--- a/src/nstack.c
+++ b/src/nstack.c
@@ -363,7 +363,6 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-
     if (ip_config(handle, 167772162, 4294967040)) {
         perror("Failed to config IP");
         exit(1);


### PR DESCRIPTION
Hello there,

for university we should find, exploit & fix buffer overflows in real world projects.

It was possible to spawn a shell using this call of strcpy you can see in the commits.
This is just a quick fix to prevent it by checking boundary sizes.