### PR TITLE
Define macros for stack ip and subnet mask

### DIFF
--- a/src/nstack.c
+++ b/src/nstack.c
@@ -363,7 +363,7 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    if (ip_config(handle, 167772162, 4294967040)) {
+    if (ip_config(handle, STACK_IP, SUBNET_MASK)) {
         perror("Failed to config IP");
         exit(1);
     }

--- a/src/nstack_ip.h
+++ b/src/nstack_ip.h
@@ -14,6 +14,16 @@
 #define IP_STR_LEN 17
 
 /**
+ * Stack ip "10.0.0.2" and subnet mask "255.255.255.0" in decimal form
+ * @{
+ */
+#define STACK_IP 167772162
+#define SUBNET_MASK 4294967040
+/**
+ * @}
+ */
+
+/**
  * IP Route descriptor.
  */
 struct ip_route {


### PR DESCRIPTION
Replace two decimal number in ip_config function call with macros to increase code readability.