### PR TITLE
Add macros from BSD queue implementation

### DIFF
--- a/src/collection.h
+++ b/src/collection.h
@@ -27,6 +27,10 @@
 #ifndef _SYS_QUEUE_H_
 #define _SYS_QUEUE_H_
 
+#include <err.h>
+
+#define QUEUEDEBUG_ABORT(...) err(1, __VA_ARGS__)
+
 /*
  * This file defines four types of data structures: singly-linked lists,
  * singly-linked tail queues, lists and tail queues.
@@ -384,6 +388,25 @@ struct qm_trace {
  * List functions.
  */
 
+#define	QMD_LIST_CHECK_HEAD(head, field) do {				\
+	if (LIST_FIRST((head)) != NULL &&				\
+	    LIST_FIRST((head))->field.le_prev !=			\
+	     &LIST_FIRST((head)))					\
+		QUEUEDEBUG_ABORT("Bad list head %p first->prev != head", (head));	\
+} while (0)
+
+#define	QMD_LIST_CHECK_NEXT(elm, field) do {				\
+	if (LIST_NEXT((elm), field) != NULL &&				\
+	    LIST_NEXT((elm), field)->field.le_prev !=			\
+	     &((elm)->field.le_next))					\
+	     	QUEUEDEBUG_ABORT("Bad link elm %p next->prev != elm", (elm));	\
+} while (0)
+
+#define	QMD_LIST_CHECK_PREV(elm, field) do {				\
+	if (*(elm)->field.le_prev != (elm))				\
+		QUEUEDEBUG_ABORT("Bad link elm %p prev->next != elm", (elm));	\
+} while (0)
+
 #define LIST_EMPTY(head) ((head)->lh_first == NULL)
 
 #define LIST_FIRST(head) ((head)->lh_first)
@@ -492,6 +515,7 @@ struct qm_trace {
 /*
  * Tail queue functions.
  */
+
 #define TAILQ_CONCAT(head1, head2, field)                           \
     do {                                                            \
         if (!TAILQ_EMPTY(head2)) {                                  \
@@ -547,6 +571,30 @@ struct qm_trace {
         (head)->tqh_last = &TAILQ_FIRST((head)); \
         QMD_TRACE_HEAD(head);                    \
     } while (0)
+
+#define	QMD_TAILQ_CHECK_HEAD(head, field) do {				\
+	if (!TAILQ_EMPTY(head) &&					\
+	    TAILQ_FIRST((head))->field.tqe_prev !=			\
+	     &TAILQ_FIRST((head)))					\
+		QUEUEDEBUG_ABORT("Bad tailq head %p first->prev != head", (head));	\
+} while (0)
+
+#define	QMD_TAILQ_CHECK_TAIL(head, field) do {				\
+	if (*(head)->tqh_last != NULL)					\
+	    	QUEUEDEBUG_ABORT("Bad tailq NEXT(%p->tqh_last) != NULL", (head)); 	\
+} while (0)
+
+#define	QMD_TAILQ_CHECK_NEXT(elm, field) do {				\
+	if (TAILQ_NEXT((elm), field) != NULL &&				\
+	    TAILQ_NEXT((elm), field)->field.tqe_prev !=			\
+	     &((elm)->field.tqe_next))					\
+		QUEUEDEBUG_ABORT("Bad link elm %p next->prev != elm", (elm));	\
+} while (0)
+
+#define	QMD_TAILQ_CHECK_PREV(elm, field) do {				\
+	if (*(elm)->field.tqe_prev != (elm))				\
+		QUEUEDEBUG_ABORT("Bad link elm %p prev->next != elm", (elm));	\
+} while (0)
 
 #define TAILQ_INSERT_AFTER(head, listelm, elm, field)                          \
     do {                                                                       \

--- a/src/udp.c
+++ b/src/udp.c
@@ -17,7 +17,7 @@
 
 RB_HEAD(udp_sock_tree, nstack_sock);
 
-static struct udp_sock_tree upd_sock_tree_head = RB_INITIALIZER();
+static struct udp_sock_tree udp_sock_tree_head = RB_INITIALIZER();
 
 static int udp_socket_cmp(struct nstack_sock *a, struct nstack_sock *b)
 {
@@ -33,7 +33,7 @@ static struct nstack_sock *find_udp_socket(const struct nstack_sockaddr *addr)
         .sock_addr = *addr,
     };
 
-    return RB_FIND(udp_sock_tree, &upd_sock_tree_head,
+    return RB_FIND(udp_sock_tree, &udp_sock_tree_head,
                    (struct nstack_sock *) (&find));
 }
 
@@ -63,7 +63,7 @@ int nstack_udp_bind(struct nstack_sock *sock)
         return -1;
     }
 
-    RB_INSERT(udp_sock_tree, &upd_sock_tree_head, sock);
+    RB_INSERT(udp_sock_tree, &udp_sock_tree_head, sock);
 
     return 0;
 }


### PR DESCRIPTION
Some macros which name start with 'QMD' were used but not yet
implemented.

Therefore, I add these macros from a slightly modified version of
BSD queue implementation (1) and check original BSD queue
implementation (2) for error handling.

(1) https://github.com/eblot/newlib/blob/master/newlib/libc/include/sys/queue.h
(2) https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/sys/sys/queue.h