### PR TITLE
Ensure deferring of IP datagram

### DIFF
--- a/src/ip_defer.c
+++ b/src/ip_defer.c
@@ -20,7 +20,7 @@ struct ip_defer {
  * This is used to inhibit defers if it's the ip deferring code itself causing
  * defer push.
  */
-static unsigned defer_inhibit;
+bool defer_inhibit;
 
 static struct ip_defer ip_defer_queue[NSTACK_IP_DEFER_MAX];
 static size_t q_rd, q_wr;

--- a/src/ip_defer.c
+++ b/src/ip_defer.c
@@ -20,7 +20,7 @@ struct ip_defer {
  * This is used to inhibit defers if it's the ip deferring code itself causing
  * defer push.
  */
-bool defer_inhibit;
+static bool defer_inhibit = false;
 
 static struct ip_defer ip_defer_queue[NSTACK_IP_DEFER_MAX];
 static size_t q_rd, q_wr;
@@ -70,11 +70,11 @@ static void ip_defer_drop(void)
 
 void ip_defer_handler(int delta_time __unused)
 {
-    defer_inhibit = 1;
+    defer_inhibit = true;
     while (1) {
         struct ip_defer *ipd = ip_defer_peek();
         if (!ipd) {
-            defer_inhibit = 0;
+            defer_inhibit = false;
             return;
         }
 
@@ -90,7 +90,7 @@ void ip_defer_handler(int delta_time __unused)
         if (ip_send(ipd->dst, ipd->proto, ipd->buf, ipd->buf_size) == -1) {
             if (errno == EHOSTUNREACH) {
                 ipd->tries++; /* Try again later. */
-                defer_inhibit = 0;
+                defer_inhibit = false;
                 return;
             }
         }

--- a/src/ip_defer.c
+++ b/src/ip_defer.c
@@ -73,7 +73,7 @@ void ip_defer_handler(int delta_time __unused)
     defer_inhibit = 1;
     while (1) {
         struct ip_defer *ipd = ip_defer_peek();
-        if (!ipd){
+        if (!ipd) {
             defer_inhibit = 0;
             return;
         }


### PR DESCRIPTION
Current code of 'ip_defer_handler' would set 'defer_inhibit' to '1' in order to avoid itself causing defer push.

However, 'defer_inhibit = 0 ' is in the outside of while loop, which means that once 'ip_defer_handler' was called, value of 'defer_inhibit' would be '1' forever, making IP datagram unable to be deferred even after return from 'ip_defer_handler'.

To fix, I make sure 'defer_inhibit = 0' would be excuted before return from 'ip_defer_handler'.